### PR TITLE
Fix the newline bug

### DIFF
--- a/src/lib/ReplyPost.svelte
+++ b/src/lib/ReplyPost.svelte
@@ -45,6 +45,8 @@
         {:else}
             <span><b>{info.u}</b> {info.p.split(/^@\w+\s\[\w+-\w+-\w+-\w+-\w+\]\s*/i).join(" ")}</span>
         {/if}
+    {:catch error}
+        <span><b>Error fetching post:</b> <code>{error}</code></span>
     {/await}
 </Container>
 

--- a/src/lib/keyDetect.js
+++ b/src/lib/keyDetect.js
@@ -1,16 +1,13 @@
-window.onkeydown = function (e) {
-    if (!e) e = window.event;
-    shiftHeld = e.shiftKey;
-}
+window.addEventListener("keydown", (e) => {
+    shiftHeld = (e.key === "Shift");
+});
 
-window.onkeyup = function (e) {
-    if (!e) e = window.event;
-    shiftHeld = e.shiftKey;
-}
+window.addEventListener("keyup", (e) => {
+    shiftHeld = (e.key === "Shift");
+});
 
-window.onmousemove = function (e) {
-    if (!e) e = window.event;
+window.addEventListener("mousemove", (e) => {
     shiftHeld = e.shiftKey;
-}
+});
 
 export let shiftHeld;


### PR DESCRIPTION
After some digging, I realized that `window.event` was deprecated, meaning that some browsers wouldn't be able to make newlines. I fixed it by replacing it with `window.addEventListener`, which should work on all browsers.